### PR TITLE
Add login form tests and trim logic

### DIFF
--- a/src/test/loginForm.js
+++ b/src/test/loginForm.js
@@ -1,16 +1,18 @@
 export const TeaLoginForm = async () => {
     let usernameTag = document.getElementById('Tea-login-username')
     let passwordTag = document.getElementById('Tea-login-password')
-    if (usernameTag.value === '') {
+    const username = usernameTag.value.trim()
+    const password = passwordTag.value.trim()
+    if (username === '') {
         throw usernameTag.getAttribute('warn');
     }
-    if(passwordTag.value === ''){
+    if (password === '') {
         throw passwordTag.getAttribute('warn')
     }
     return new Promise((resolve, reject) => {
         const data = {
-            username: usernameTag.value,
-            password: passwordTag.value,
+            username,
+            password,
         };
         resolve(data); // 将数据对象传递给resolve
     });

--- a/src/test/loginForm.test.js
+++ b/src/test/loginForm.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+
+async function loadModule() {
+  return await import('./loginForm.js');
+}
+
+function setupDocument(username, password) {
+  global.document = {
+    getElementById(id) {
+      if (id === 'Tea-login-username') {
+        return {
+          value: username,
+          getAttribute(attr) { return attr === 'warn' ? 'username required' : null; }
+        };
+      }
+      if (id === 'Tea-login-password') {
+        return {
+          value: password,
+          getAttribute(attr) { return attr === 'warn' ? 'password required' : null; }
+        };
+      }
+      return null;
+    }
+  };
+}
+
+(async () => {
+  const { TeaLoginForm } = await loadModule();
+
+  // should return username and password
+  setupDocument('user', 'pass');
+  let result = await TeaLoginForm();
+  assert.deepStrictEqual(result, { username: 'user', password: 'pass' });
+
+  // values should be trimmed before validation
+  setupDocument('  user  ', '  pass  ');
+  result = await TeaLoginForm();
+  assert.deepStrictEqual(result, { username: 'user', password: 'pass' });
+
+  // should throw when username empty
+  setupDocument('', 'pass');
+  await TeaLoginForm().then(() => assert.fail('expected error'), err => {
+    assert.strictEqual(err, 'username required');
+  });
+
+  // should throw when password empty
+  setupDocument('user', '');
+  await TeaLoginForm().then(() => assert.fail('expected error'), err => {
+    assert.strictEqual(err, 'password required');
+  });
+
+  console.log('All tests passed');
+})();


### PR DESCRIPTION
## Summary
- trim username/password values in `TeaLoginForm`
- add a Node-based test verifying returned values, trimming, and error messages

## Testing
- `node src/test/loginForm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_683fe7d62ee8832bba3de51fec09a712